### PR TITLE
avoid the usage of npm i, use npm install instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
       - run:
           name: install-serverless-and dependencies
           command: |
-            sudo npm i -g serverless@1.25.0 codecov
-            npm i
+            sudo npm install -g serverless@1.25.0 codecov
+            npm install
 
       - run:
           name: test


### PR DESCRIPTION
Eliminate the random-failing builds.

Source: https://discuss.circleci.com/t/yarn-permission-denied/20160/7